### PR TITLE
fix: use eval instead of require

### DIFF
--- a/lib/mock-node.js
+++ b/lib/mock-node.js
@@ -6,7 +6,7 @@ var path = require('path'),
     CacheStorage = require('enb/lib/cache/cache-storage'),
     Cache = require('enb/lib/cache/cache'),
     asyncFs = require('enb').asyncFs,
-    clearRequire = require('clear-require');
+    safeEval = require('gulp-eval').eval;
 
 module.exports = inherit({
     __constructor: function (nodePath) {
@@ -224,8 +224,10 @@ module.exports = inherit({
                 return this._buildDefer.promise().then(function () {
                     return vow.all(tech.getTargets().map(function (targetName) {
                         var filename = _this.resolvePath(targetName);
-                        clearRequire(filename);
-                        return require(filename);
+
+                        return asyncFs.read(filename, 'utf-8').then(function (source) {
+                            return safeEval(source);
+                        });
                     }, this));
                 }.bind(this));
             }.bind(this));

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "clear-require": "1.0.1",
+    "gulp-eval": "1.0.0-0",
     "inherit": "2.2.2",
     "vow": "0.4.11"
   },


### PR DESCRIPTION
Resolved #10 

In most ENB packages used `mock-fs` to testing.

The `mock-fs` does not support `require` for `Node.js 4`: https://github.com/tschaub/mock-fs/issues/43.

Because of this `node.runTechAndRequire()` will throw error:

```
Cannot find module 'path/to/file.js'
```
